### PR TITLE
Optional case sensitivity for str_contains helper function

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -62,12 +62,13 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|array  $needles
+     * @param  boolean  $caseSensitive  (optional)
      * @return bool
      */
-    public static function contains($haystack, $needles)
+    public static function contains($haystack, $needles, $caseSensitive = true)
     {
         foreach ((array) $needles as $needle) {
-            if ($needle != '' && strpos($haystack, $needle) !== false) {
+            if ($needle != '' && ($caseSensitive ? strpos($haystack, $needle) : stripos($haystack, $needle)) !== false) {
                 return true;
             }
         }


### PR DESCRIPTION
Ability to call `str_contains` with 3rd optional parameter for case sensitivity