### PR TITLE
Replicate with default except values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3048,11 +3048,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function replicate(array $except = null)
     {
-        $except = $except ?: [
+        $default = [
             $this->getKeyName(),
             $this->getCreatedAtColumn(),
             $this->getUpdatedAtColumn(),
         ];
+        
+        $except = $except ? array_unique(array_merge($except, $default)) : $default;
 
         $attributes = Arr::except($this->attributes, $except);
 


### PR DESCRIPTION
When using `replicate` with specified 'except' columns the primary key, created at and updated at timestamp have to be specified manually. This change proposes to use them by default.

For example 
```php
$duplicate = $example->replicate([
    'description',
    $example->getKeyName(),
    $example->getUpdatedAtColumn(),
    $example->getCreatedAtColumn(),
]);
```
would be simplified to 
```php
$duplicate = $example->replicate([
    'description',
]);
```

Another option could be adding a boolean $useDefault (`= false` by default to be backwards compatible) argument to the method to determine whether or not to add primary key, created at and updated at timestamp columns.
```php
$duplicate = $example->replicate([
    'description',
], true);
// Would be the same as
$duplicate = $example->replicate([
    'description',
    $example->getKeyName(),
    $example->getUpdatedAtColumn(),
    $example->getCreatedAtColumn(),
]);
```